### PR TITLE
Remove unnecessary @MappingTo annotations from entities

### DIFF
--- a/backend/src/main/java/com/example/Category.java
+++ b/backend/src/main/java/com/example/Category.java
@@ -1,11 +1,9 @@
 package com.example;
 
-import io.quarkus.hibernate.orm.panache.MappingTo;
 import jakarta.persistence.*;
 
 @Entity
 @Table(name = "categories")
-@MappingTo(Category.class)
 public class Category {
 
     @Id

--- a/backend/src/main/java/com/example/Dish.java
+++ b/backend/src/main/java/com/example/Dish.java
@@ -1,12 +1,10 @@
 package com.example;
 
-import io.quarkus.hibernate.orm.panache.MappingTo;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 
 @Entity
 @Table(name = "dishes")
-@MappingTo(Dish.class)
 public class Dish {
 
     @Id

--- a/backend/src/main/java/com/example/Restaurant.java
+++ b/backend/src/main/java/com/example/Restaurant.java
@@ -1,6 +1,5 @@
 package com.example;
 
-import io.quarkus.hibernate.orm.panache.MappingTo;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -8,7 +7,6 @@ import java.util.List;
 
 @Entity
 @Table(name = "restaurants")
-@MappingTo(Restaurant.class)
 public class Restaurant {
 
     @Id

--- a/backend/src/main/java/com/example/RestaurantCategory.java
+++ b/backend/src/main/java/com/example/RestaurantCategory.java
@@ -1,11 +1,9 @@
 package com.example;
 
-import io.quarkus.hibernate.orm.panache.MappingTo;
 import jakarta.persistence.*;
 
 @Entity
 @Table(name = "restaurant_categories")
-@MappingTo(RestaurantCategory.class)
 public class RestaurantCategory {
 
     @EmbeddedId


### PR DESCRIPTION
## Summary of Changes\n\nThis PR removes the unnecessary `@MappingTo` annotations from entity classes in the backend:\n\n- Removed `@MappingTo(Category.class)` from Category.java\n- Removed `@MappingTo(Dish.class)` from Dish.java\n- Removed `@MappingTo(Restaurant.class)` from Restaurant.java\n- Removed `@MappingTo(RestaurantCategory.class)` from RestaurantCategory.java\n\n## Justification\n\nThe `@MappingTo` annotations were not needed in this context because:\n1. The entities are mapped directly to themselves, which is redundant\n2. The project uses Quarkus with Hibernate ORM Panache and functions correctly without these annotations\n3. These annotations are typically used for special mapping scenarios (like DTOs), but don't apply here\n\nThis change simplifies the code while maintaining full functionality.\n\n## Testing\n\nThe changes have been verified to not introduce any functional issues in the backend services.