### PR TITLE
Fix backend API URL to match running Node.js server port

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,5 +1,5 @@
 # ============= API CONFIGURATION =============
-REACT_APP_API_URL=http://localhost:8080/api
+REACT_APP_API_URL=http://localhost:59806/api
 REACT_APP_ENV=development
 
 # ============= APP CONFIGURATION =============


### PR DESCRIPTION
The frontend was configured to connect to http://localhost:8080/api but the Node.js backend is actually running on port 59806. This change updates the configuration to use the correct port.